### PR TITLE
Add offline Docker image caching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,4 @@ dmypy.json
 # Docker
 .env
 docker-compose.override.yml
+offline_images/

--- a/README.md
+++ b/README.md
@@ -29,19 +29,22 @@ cd ai-prepper
 cp .env.example .env
 # Edit .env if needed (especially for external drive setup)
 
-# 3. Initial setup
+# 3. Cache Docker images for offline use
+make cache-images
+
+# 4. Initial setup
 make setup
 
-# 4. Start all services
+# 5. Start all services
 make up
 
-# 5. Pull AI models (requires internet, ~5GB)
+# 6. Pull AI models (requires internet, ~5GB)
 make pull-models
 
-# 6. Download Wikipedia (requires internet, ~20GB)
+# 7. Download Wikipedia (requires internet, ~20GB)
 make download-wiki
 
-# 7. Process Wikipedia into vector database
+# 8. Process Wikipedia into vector database
 make process
 ```
 
@@ -52,6 +55,12 @@ Once running, access these services:
 - **Flowise UI**: http://localhost:3000 - Complete chat interface and workflow builder
 - **Ollama API**: http://localhost:11434 - LLM server (used by Flowise)
 - **ChromaDB API**: http://localhost:8000 - Vector database (used by Flowise)
+
+## 💽 Offline Docker Images
+
+Run `make cache-images` while online to pull all Docker containers and store them
+as tar files under `offline_images/`. On a new machine without internet access,
+restore them with `make load-images` before running `make up`.
 
 ## 📁 Project Structure
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,9 +60,10 @@ services:
 
   # Wikipedia Processor - Custom service for data ingestion
   processor:
-    build: 
+    build:
       context: .
       dockerfile: Dockerfile
+    image: ai-prepper/processor:latest
     container_name: ai-prepper-processor
     volumes:
       - wikipedia_data:/app/data

--- a/scripts/cache_images.sh
+++ b/scripts/cache_images.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Pull and save required Docker images for offline use
+set -e
+
+DIR="${1:-offline_images}"
+mkdir -p "$DIR"
+
+IMAGES=(
+  "ollama/ollama:latest"
+  "chromadb/chroma:latest"
+  "flowiseai/flowise:latest"
+  "ai-prepper/processor:latest"
+)
+
+echo "Pulling Docker images..."
+docker-compose pull ollama chromadb flowise
+# build processor image
+docker-compose build processor
+
+for img in "${IMAGES[@]}"; do
+  fname=$(echo "$img" | tr '/:' '_').tar
+  echo "Saving $img to $DIR/$fname"
+  docker save "$img" -o "$DIR/$fname"
+done
+
+echo "All images saved to $DIR"
+


### PR DESCRIPTION
## Summary
- add Makefile targets to pull, cache, and load Docker images
- new script `cache_images.sh` to store images as tar files
- save processor image in docker-compose for easy export
- document offline image workflow in README
- ignore `offline_images/` directory in git

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_684d16510884832fbb56aa3b13c1d509